### PR TITLE
Resolve the dependencies version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@jup-ag/core": "^0.0.0-alpha.22",
+    "@solana/buffer-layout": "4.0.0",
     "@solana/wallet-adapter-base": "^0.7.1",
     "@solana/web3.js": "^1.31.0",
     "@types/bs58": "^4.0.1",
@@ -32,5 +33,8 @@
     "nodemon": "^2.0.15",
     "parcel": "^2.0.1",
     "typescript": "^4.5.3"
+  },
+  "resolutions": {
+    "@solana/buffer-layout": "4.0.0"
   }
 }


### PR DESCRIPTION
Hi Jupiter team, I'm trying to use the `jup.ag/core` library in my project, but I always got this error: 

```
fields must be array of Layout instances
```

This error is caused by `@jup-ag/core` and `@saber-hq` depending on different versions of `@solana/buffer-layout`,  so you need to add to the `package.json`

```
  "resolutions": {
    "@solana/buffer-layout": "4.0.0"
  }
```

I simply ran `ts-node src/index`, and the test results met expectations